### PR TITLE
增加 edit 命令对 force, siteList, useFilter 参数的支持

### DIFF
--- a/bin/bdh.js
+++ b/bin/bdh.js
@@ -23,8 +23,13 @@ const { argv } = yargs
   .example('bdh create 2016q4', '生成 2016 第四季度的数据')
   .command('update <month>', '更新某月的番组数据', {}, update)
   .example('bdh update 201610', '更新 2016 年 10 月的番剧数据')
-  .command('edit <month>', '交互式地编辑某月的番剧数据', {}, edit)
-  .example('bdh edit 201610', '交互式地 2016 年 10 月的番剧数据的放送站点')
+  .command('edit <month> [siteList..]', '交互式地编辑某月的番剧数据', {}, edit)
+  .example([
+    ['bdh edit 201610', '交互式地编辑 2016 年 10 月的番剧数据的所有放送站点'],
+    ['bdh edit 201610 nicovideo', '交互式地编辑 2016 年 10 月的番剧数据的nicovideo站点'],
+    ['bdh edit 201610 nicovideo gamer', '交互式地编辑 2016 年 10 月的番剧数据的nicovideo与gamer站点'],
+    ['bdh edit 201610 gamer*', '交互式地编辑 2016 年 10 月的番剧数据的gamer与gamer_hk站点'],
+  ])
   .command('add <bangumiId> [siteList..]', '根据bangumi添加番剧数据', {}, add)
   .example([
     ['bdh add 207195', '添加《ゆるキャン△》'],

--- a/bin/bdh.js
+++ b/bin/bdh.js
@@ -37,17 +37,26 @@ const { argv } = yargs
   .example('bdh end', '补充所有 end 字段为空的番剧')
   .command('cleanup <site>', '清理已下架番剧', {}, cleanup)
   .example('bdh cleanup', '清理已下架番剧')
-  .alias('f', 'force')
-  .describe('f', '强制覆写已存在的数据')
-  .default('f', false)
-  .global('f')
-  .alias('i', 'input')
-  .describe('i', '数据输入目录')
-  .default('i', DEFAULT_DIR)
-  .global('i')
-  .alias('o', 'output')
-  .describe('o', '数据输出目录')
-  .default('o', DEFAULT_DIR)
-  .global('o')
+  .option('f', {
+    alias: 'force',
+    type: 'boolean',
+    describe: '强制覆写已存在的数据',
+    default: false,
+    global: true,
+  })
+  .option('i', {
+    alias: 'input',
+    type: 'string',
+    describe: '数据输入目录',
+    default: DEFAULT_DIR,
+    global: true,
+  })
+  .option('o', {
+    alias: 'output',
+    type: 'string',
+    describe: '数据输出目录',
+    default: DEFAULT_DIR,
+    global: true,
+  })
   .alias('h', 'help')
   .alias('v', 'version');

--- a/bin/bdh.js
+++ b/bin/bdh.js
@@ -23,7 +23,16 @@ const { argv } = yargs
   .example('bdh create 2016q4', '生成 2016 第四季度的数据')
   .command('update <month>', '更新某月的番组数据', {}, update)
   .example('bdh update 201610', '更新 2016 年 10 月的番剧数据')
-  .command('edit <month> [siteList..]', '交互式地编辑某月的番剧数据', {}, edit)
+  .command(
+    'edit <month> [siteList..]',
+    '交互式地编辑某月的番剧数据',
+    yargs => yargs.option('useFilter', {
+      type: 'boolean',
+      describe: '过滤不包含 siteList 内已有站点的番剧',
+      default: false,
+    }),
+    edit
+  )
   .example([
     ['bdh edit 201610', '交互式地编辑 2016 年 10 月的番剧数据的所有放送站点'],
     ['bdh edit 201610 nicovideo', '交互式地编辑 2016 年 10 月的番剧数据的nicovideo站点'],

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -111,6 +111,7 @@ module.exports = async function edit({
         seqSites,
         siteList,
         isFromValidate,
+        useFilter,
       });
     if (!result) return undefined;
 

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -10,8 +10,8 @@ inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'))
 module.exports = async function edit({
   input,
   month,
-  itemIndex, // validate 命令调用
-  site,      // validate 命令调用
+  siteList,
+  itemIndex, // validate 命令调用时专用
   force,
 }) {
   const itemsJsonFile = path.resolve(input, String(month)
@@ -66,11 +66,11 @@ module.exports = async function edit({
     return selectIndex;
   }
 
-  const editOnce = async (selectIndex, selectSite) => {
+  const editOnce = async (selectIndex) => {
     selectIndex ??= await selectItem();
 
-    let siteType = 'onair';
-    if (!selectSite) {
+    let siteType = 'onair'; // 强制认为siteList参数均为放送站点
+    if (siteList.length === 0) {
       siteTypeAnswers = await inquirer
         .prompt([
           {
@@ -91,7 +91,7 @@ module.exports = async function edit({
 
     const seqSites = items[selectIndex].sites;
     const { preInfoIndex, info } = await sites[siteType]
-      .add({ seqSites, onairSites, selectSite });
+      .add({ seqSites, onairSites, siteList });
     const preInfo = seqSites[preInfoIndex];
     console.log({ preInfo, info });
     if (force && preInfo) {
@@ -105,7 +105,7 @@ module.exports = async function edit({
   }
 
   if (itemIndex !== undefined) {
-    await editOnce(itemIndex, site);
+    await editOnce(itemIndex);
     return;
   }
 
@@ -119,7 +119,7 @@ module.exports = async function edit({
         type: 'list',
         name: 'cont',
         message: '继续编辑？',
-        choices: ['本番剧', '其他番剧', '退出'],
+        choices: ['其他番剧', '本番剧', '退出'],
         default: true,
       }
     ]);

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -18,6 +18,8 @@ module.exports = async function edit({
   itemIndex, // validate 命令调用时专用
   force,
 }) {
+  const isFromValidate = itemIndex !== undefined;
+
   const itemsJsonFile = path.resolve(input, String(month)
     .replace(/(\d{4})(\d\d)/, '$1/$2.json'));
   const items = await fs.readJson(itemsJsonFile);
@@ -69,7 +71,7 @@ module.exports = async function edit({
 
     if (selectIndex === -1) {
       console.error('所选番剧未找到');
-      return selectItem();
+      return await selectItem();
     }
     return selectIndex;
   }
@@ -99,7 +101,12 @@ module.exports = async function edit({
 
     const seqSites = items[selectIndex].sites;
     const { oldInfoIndex, info } = await sites[siteType]
-      .add({ seqSites, onairSites, siteList });
+      .add({
+        seqSites,
+        onairSites,
+        siteList,
+        isFromValidate,
+      });
     const oldInfo = seqSites[oldInfoIndex];
     console.log({ oldInfo, info });
     if (force && oldInfo) {
@@ -112,7 +119,7 @@ module.exports = async function edit({
     return selectIndex;
   }
 
-  if (itemIndex !== undefined) {
+  if (isFromValidate) {
     await editOnce(itemIndex);
     return;
   }

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -10,6 +10,7 @@ inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'))
 module.exports = async function edit({
   input,
   month,
+  force,
 }) {
   const itemsJsonFile = path.resolve(input, String(month)
     .replace(/(\d{4})(\d\d)/, '$1/$2.json'));
@@ -77,8 +78,14 @@ module.exports = async function edit({
   }
 
   const seqSites = items[selectIndex].sites;
-  const info = await sites[siteType].add(seqSites, onairSites);
-  items[selectIndex].sites.push(info);
+  const { preInfoIndex, info } = await sites[siteType].add(seqSites, onairSites);
+  const preInfo = seqSites[preInfoIndex];
+  console.log({ preInfo, info });
+  if (force && preInfo) {
+    seqSites[preInfoIndex] = info;
+  } else {
+    items[selectIndex].sites.push(info);
+  }
 
   await fs.outputJson(itemsJsonFile, items, { spaces: 2 });
 };

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -35,57 +35,95 @@ module.exports = async function edit({
     return acc;
   }, []);
 
-  const { select } = await inquirer
-    .prompt([
-      {
-        type: 'autocomplete',
-        name: 'select',
-        message: '选择番剧',
-        source: (_, i = '') => new Promise((resolve) => {
-          const fuzzyResult = fuzzy.filter(i, titleList);
-          resolve(
-            fuzzyResult.map((el) => el.original),
-          );
-        }),
-      },
-    ]);
+  const selectItem = async () => {
+    const { select } = await inquirer
+      .prompt([
+        {
+          type: 'autocomplete',
+          name: 'select',
+          message: '选择番剧',
+          source: (_, i = '') => new Promise((resolve) => {
+            const fuzzyResult = fuzzy.filter(i, titleList);
+            resolve(
+              fuzzyResult.map((el) => el.original),
+            );
+          }),
+        },
+      ]);
 
-  const selectIndex = items.findIndex(({
-    title,
-    titleTranslate = {},
-  }) => title === select || flatten(values(titleTranslate))
-    .includes(select));
+    const selectIndex = items.findIndex(({
+      title,
+      titleTranslate = {},
+    }) => title === select || flatten(values(titleTranslate))
+      .includes(select));
 
-  if (selectIndex === -1) {
-    console.error('所选番剧未找到');
-    process.exit(1);
+    if (selectIndex === -1) {
+      console.error('所选番剧未找到');
+      return selectItem();
+    }
+    return selectIndex;
   }
 
-  const { siteType } = await inquirer
-    .prompt([
+  const editOnce = async (selectIndex) => {
+    selectIndex ??= await selectItem();
+
+    const { siteType } = await inquirer
+      .prompt([
+        {
+          type: 'list',
+          name: 'siteType',
+          message: '选择站点类型',
+          choices: ['onair'],
+          default: 'onair',
+        },
+      ]);
+
+    if (!sites[siteType]) {
+      console.error('不支持所选站点类型');
+      process.exit(1);
+    }
+
+    const seqSites = items[selectIndex].sites;
+    const { preInfoIndex, info } = await sites[siteType].add(seqSites, onairSites);
+    const preInfo = seqSites[preInfoIndex];
+    console.log({ preInfo, info });
+    if (force && preInfo) {
+      seqSites[preInfoIndex] = info;
+    } else {
+      items[selectIndex].sites.push(info);
+    }
+
+    await fs.outputJson(itemsJsonFile, items, { spaces: 2 });
+    return selectIndex;
+  }
+
+  let again = true;
+  let retainedSelectIndex = null;
+
+  while(again) {
+    const selectIndex = await editOnce(retainedSelectIndex);
+    const { cont } = await inquirer.prompt([
       {
         type: 'list',
-        name: 'siteType',
-        message: '选择站点类型',
-        choices: ['onair'],
-        default: 'onair',
-      },
+        name: 'cont',
+        message: '继续编辑？',
+        choices: ['本番剧', '其他番剧', '退出'],
+        default: true,
+      }
     ]);
-
-  if (!sites[siteType]) {
-    console.error('不支持所选站点类型');
-    process.exit(1);
+    switch (cont) {
+      case '本番剧':
+        again = true;
+        retainedSelectIndex = selectIndex;
+        break;
+      case '其他番剧':
+        again = true;
+        retainedSelectIndex = null;
+        break;
+      case '退出':
+        again = false;
+        retainedSelectIndex = null;
+        break;
+    }
   }
-
-  const seqSites = items[selectIndex].sites;
-  const { preInfoIndex, info } = await sites[siteType].add(seqSites, onairSites);
-  const preInfo = seqSites[preInfoIndex];
-  console.log({ preInfo, info });
-  if (force && preInfo) {
-    seqSites[preInfoIndex] = info;
-  } else {
-    items[selectIndex].sites.push(info);
-  }
-
-  await fs.outputJson(itemsJsonFile, items, { spaces: 2 });
 };

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -30,6 +30,7 @@ module.exports = async function edit({
   const onairSites = fs.existsSync(onairSitesJsonFile)
     ? await fs.readJson(onairSitesJsonFile)
     : undefined;
+  sites.onair.init(onairSites);
 
   const titleList = items.reduce((acc, {
     title,
@@ -103,7 +104,6 @@ module.exports = async function edit({
     const result = await sites[siteType]
       .add({
         seqSites,
-        onairSites,
         siteList,
         isFromValidate,
       });

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -11,9 +11,16 @@ module.exports = async function edit({
   input,
   month,
 }) {
-  const jsonFile = path.resolve(input, String(month)
+  const itemsJsonFile = path.resolve(input, String(month)
     .replace(/(\d{4})(\d\d)/, '$1/$2.json'));
-  const items = await fs.readJson(jsonFile);
+  const items = await fs.readJson(itemsJsonFile);
+
+  const onairSitesJsonFile = path.join(
+    path.dirname(input), 'sites', 'onair.json'
+  );
+  const onairSites = fs.existsSync(onairSitesJsonFile)
+    ? await fs.readJson(onairSitesJsonFile)
+    : undefined;
 
   const titleList = items.reduce((acc, {
     title,
@@ -69,8 +76,8 @@ module.exports = async function edit({
     process.exit(1);
   }
 
-  const info = await sites[siteType].add();
+  const info = await sites[siteType].add(onairSites);
   items[selectIndex].sites.push(info);
 
-  await fs.outputJson(jsonFile, items, { spaces: 2 });
+  await fs.outputJson(itemsJsonFile, items, { spaces: 2 });
 };

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -100,13 +100,16 @@ module.exports = async function edit({
     }
 
     const seqSites = items[selectIndex].sites;
-    const { oldInfoIndex, info } = await sites[siteType]
+    const result = await sites[siteType]
       .add({
         seqSites,
         onairSites,
         siteList,
         isFromValidate,
       });
+    if (!result) return undefined;
+
+    const { oldInfoIndex, info } = result;
     const oldInfo = seqSites[oldInfoIndex];
     console.log({ oldInfo, info });
     if (force && oldInfo) {
@@ -129,6 +132,10 @@ module.exports = async function edit({
 
   while(again) {
     const selectIndex = await editOnce(retainedSelectIndex);
+    if (selectIndex === undefined) {
+      retainedSelectIndex = null;
+      continue;
+    }
     const { cont } = await inquirer.prompt([
       {
         type: 'list',
@@ -140,16 +147,13 @@ module.exports = async function edit({
     ]);
     switch (cont) {
       case '本番剧':
-        again = true;
         retainedSelectIndex = selectIndex;
         break;
       case '其他番剧':
-        again = true;
         retainedSelectIndex = null;
         break;
       case '退出':
         again = false;
-        retainedSelectIndex = null;
         break;
     }
   }

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -16,6 +16,7 @@ module.exports = async function edit({
   month,
   siteList,
   itemIndex, // validate 命令调用时专用
+  useFilter,
   force,
 }) {
   const isFromValidate = itemIndex !== undefined;
@@ -32,7 +33,11 @@ module.exports = async function edit({
     : undefined;
   sites.onair.init(onairSites);
 
-  const titleList = items.reduce((acc, {
+  const filteredItems = useFilter
+    ? items.filter(({ sites: seqSites }) => sites.onair.includes(seqSites, siteList))
+    : items;
+
+  const titleList = filteredItems.reduce((acc, {
     title,
     titleTranslate = {},
   }) => {

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -10,6 +10,8 @@ inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'))
 module.exports = async function edit({
   input,
   month,
+  itemIndex, // validate 命令调用
+  site,      // validate 命令调用
   force,
 }) {
   const itemsJsonFile = path.resolve(input, String(month)
@@ -64,19 +66,23 @@ module.exports = async function edit({
     return selectIndex;
   }
 
-  const editOnce = async (selectIndex) => {
+  const editOnce = async (selectIndex, selectSite) => {
     selectIndex ??= await selectItem();
 
-    const { siteType } = await inquirer
-      .prompt([
-        {
-          type: 'list',
-          name: 'siteType',
-          message: '选择站点类型',
-          choices: ['onair'],
-          default: 'onair',
-        },
-      ]);
+    let siteType = 'onair';
+    if (!selectSite) {
+      siteTypeAnswers = await inquirer
+        .prompt([
+          {
+            type: 'list',
+            name: 'siteType',
+            message: '选择站点类型',
+            choices: ['onair'],
+            default: 'onair',
+          },
+        ]);
+      siteType = siteTypeAnswers.siteType;
+    }
 
     if (!sites[siteType]) {
       console.error('不支持所选站点类型');
@@ -84,7 +90,8 @@ module.exports = async function edit({
     }
 
     const seqSites = items[selectIndex].sites;
-    const { preInfoIndex, info } = await sites[siteType].add(seqSites, onairSites);
+    const { preInfoIndex, info } = await sites[siteType]
+      .add({ seqSites, onairSites, selectSite });
     const preInfo = seqSites[preInfoIndex];
     console.log({ preInfo, info });
     if (force && preInfo) {
@@ -95,6 +102,11 @@ module.exports = async function edit({
 
     await fs.outputJson(itemsJsonFile, items, { spaces: 2 });
     return selectIndex;
+  }
+
+  if (itemIndex !== undefined) {
+    await editOnce(itemIndex, site);
+    return;
   }
 
   let again = true;

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -7,6 +7,9 @@ const sites = require('../sites/index.js');
 
 inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
 
+const rawTitlePref = '$ ';
+const othTitlePref = ' '.repeat(rawTitlePref.length);
+
 module.exports = async function edit({
   input,
   month,
@@ -29,16 +32,16 @@ module.exports = async function edit({
     title,
     titleTranslate = {},
   }) => {
-    acc.push(title);
+    acc.push(rawTitlePref + title);
     Object.keys(titleTranslate)
       .forEach((key) => {
-        acc.push(...titleTranslate[key]);
+        acc.push(...titleTranslate[key].map((v) => othTitlePref + v));
       });
     return acc;
   }, []);
 
   const selectItem = async () => {
-    const { select } = await inquirer
+    let { select } = await inquirer
       .prompt([
         {
           type: 'autocomplete',
@@ -52,6 +55,7 @@ module.exports = async function edit({
           }),
         },
       ]);
+    select = select.slice(rawTitlePref.length);
 
     const selectIndex = items.findIndex(({
       title,

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -76,7 +76,8 @@ module.exports = async function edit({
     process.exit(1);
   }
 
-  const info = await sites[siteType].add(onairSites);
+  const seqSites = items[selectIndex].sites;
+  const info = await sites[siteType].add(seqSites, onairSites);
   items[selectIndex].sites.push(info);
 
   await fs.outputJson(itemsJsonFile, items, { spaces: 2 });

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -4,8 +4,9 @@ const inquirer = require('inquirer');
 const fuzzy = require('fuzzy');
 const { flatten, values } = require('lodash');
 const sites = require('../sites/index.js');
+const { AutocompletePrompt } = require('../utils');
 
-inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
+inquirer.registerPrompt('autocomplete', AutocompletePrompt);
 
 const rawTitlePref = '$ ';
 const othTitlePref = ' '.repeat(rawTitlePref.length);
@@ -40,6 +41,7 @@ module.exports = async function edit({
     return acc;
   }, []);
 
+  let preTitle = undefined;
   const selectItem = async () => {
     let { select } = await inquirer
       .prompt([
@@ -47,6 +49,7 @@ module.exports = async function edit({
           type: 'autocomplete',
           name: 'select',
           message: '选择番剧',
+          default: preTitle,
           source: (_, i = '') => new Promise((resolve) => {
             const fuzzyResult = fuzzy.filter(i, titleList);
             resolve(
@@ -55,6 +58,7 @@ module.exports = async function edit({
           }),
         },
       ]);
+    preTitle = select;
     select = select.slice(rawTitlePref.length);
 
     const selectIndex = items.findIndex(({

--- a/lib/commands/edit.js
+++ b/lib/commands/edit.js
@@ -90,12 +90,12 @@ module.exports = async function edit({
     }
 
     const seqSites = items[selectIndex].sites;
-    const { preInfoIndex, info } = await sites[siteType]
+    const { oldInfoIndex, info } = await sites[siteType]
       .add({ seqSites, onairSites, siteList });
-    const preInfo = seqSites[preInfoIndex];
-    console.log({ preInfo, info });
-    if (force && preInfo) {
-      seqSites[preInfoIndex] = info;
+    const oldInfo = seqSites[oldInfoIndex];
+    console.log({ oldInfo, info });
+    if (force && oldInfo) {
+      seqSites[oldInfoIndex] = info;
     } else {
       items[selectIndex].sites.push(info);
     }

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -56,9 +56,15 @@ let baseSiteList = [
   'prime',
 ];
 
+let addedSiteList = [];
+
+function addSitePref(site) {
+  return addedSiteList.has(site) ? addedSitePref + site : site;
+}
+
 exports.add = async function add({ seqSites, onairSites, siteList }) {
   if (onairSites) baseSiteList = Object.keys(onairSites);
-  const addedSites = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
+  addedSiteList = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
 
   let defaultTime = dayjs().startOf('quarter').format('YYYYMMDDHHmmss');
   const getTime = (input = '', value = '') => {
@@ -79,7 +85,7 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
       console.error('不支持所选站点', siteList, '请重新选择');
     }
     options = options.map(
-      (site) => addedSites.has(site) ? addedSitePref + site : site
+      (site) => addSitePref(site)
     );
     const { site } = await inquirer.prompt([
       {
@@ -107,7 +113,7 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
       await selectSite(baseSiteList, true);
     } else if (length === 1) {
       selectedSite = siteOptions[0];
-      ora().succeed(`站点名称 ${chalk.cyan(selectedSite)}`);
+      ora().succeed(`站点名称 ${chalk.cyan(addSitePref(selectedSite))}`);
     } else {
       await selectSite(siteOptions);
     }

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -95,6 +95,7 @@ exports.add = async function add({
   seqSites,       // 已有的站点信息
   siteList,       // 待选放送站点列表
   isFromValidate, // 由 validate 命令发起调用
+  useFilter,
 }) {
   getAddedSiteSet(seqSites);
 
@@ -149,7 +150,7 @@ exports.add = async function add({
     const length = siteOptions.length;
     if (length === 0) {
       await selectSite(baseSiteList, true);
-    } else if (length === 1 && isFromValidate) {
+    } else if (length === 1 && (isFromValidate || useFilter)) {
       selectedSite = siteOptions[0];
       ora().succeed(`站点名称 ${chalk.cyan(addSitePref(selectedSite))}`);
     } else {

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -18,6 +18,10 @@ const cycleList = {
   月播: 'P1M',
 };
 
+const invertedCycleList = Object.fromEntries(
+  Object.entries(cycleList).map(([key, value]) => [value, key])
+);
+
 let siteList = [
   'acfun',
   'bilibili',
@@ -48,10 +52,10 @@ let siteList = [
   'prime',
 ];
 
-exports.add = async function add(onairSites) {
+exports.add = async function add(seqSites, onairSites) {
   if (onairSites) siteList = Object.keys(onairSites);
 
-  const defaultTime = dayjs().startOf('quarter').format('YYYYMMDDHHmmss');
+  let defaultTime = dayjs().startOf('quarter').format('YYYYMMDDHHmmss');
   const getTime = (input = '', value = '') => {
     const start = `${input}`.slice(0, 14);
     const base = value !== '' ? getTime(`${value}`).plainTime : defaultTime;
@@ -64,7 +68,7 @@ exports.add = async function add(onairSites) {
     };
   };
 
-  const answers = await inquirer.prompt([
+  const siteAnswers = await inquirer.prompt([
     {
       type: 'autocomplete',
       name: 'site',
@@ -76,17 +80,37 @@ exports.add = async function add(onairSites) {
         );
       }),
     },
+  ]);
+
+  const preInfoIndex = seqSites.findIndex((site) => site.site === siteAnswers.site);
+  const preInfo = seqSites[preInfoIndex];
+  if (preInfo?.begin) {
+    defaultTime = dayjs.utc(preInfo.begin).local().format('YYYYMMDDHHmmss');
+  }
+
+  const urlAnswers = await inquirer.prompt([
     {
       type: 'input',
       name: 'id',
       message: '站点 id',
+      default: preInfo?.id,
     },
     {
       type: 'input',
       name: 'url',
       message: '完整 url',
+      default: preInfo?.url,
       when: (a) => !a.id,
     },
+  ]);
+
+  if (onairSites) {
+    const url = urlAnswers.url
+      ?? onairSites[siteAnswers.site].urlTemplate.replace('{{id}}', urlAnswers.id);
+    console.log({ url });
+  }
+
+  const answers = await inquirer.prompt([
     {
       type: 'input',
       name: 'begin',
@@ -103,7 +127,7 @@ exports.add = async function add(onairSites) {
       name: 'cycle',
       message: '周期',
       choices: Object.keys(cycleList),
-      default: '周播',
+      default: invertedCycleList[preInfo?.broadcast.split('/').pop()] || '周播',
     },
     {
       type: 'input',
@@ -122,13 +146,14 @@ exports.add = async function add(onairSites) {
       type: 'input',
       name: 'comment',
       message: '备注',
+      default: preInfo?.comment
     },
   ]);
 
   return {
-    site: answers.site,
-    id: answers.id,
-    ...(answers.url ? { url: answers.url } : {}),
+    site: siteAnswers.site,
+    id: urlAnswers.id,
+    ...(urlAnswers.url ? { url: urlAnswers.url } : {}),
     begin: dayjs(getTime(answers.begin).plainTime).toISOString(),
     broadcast: `R/${dayjs(getTime(answers.broadcast, answers.begin).plainTime).toISOString()}/${cycleList[answers.cycle] || 'P7D'}`,
     ...(answers.comment ? { comment: answers.comment } : {}),

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -18,7 +18,7 @@ const cycleList = {
   月播: 'P1M',
 };
 
-const siteList = [
+let siteList = [
   'acfun',
   'bilibili',
   'bilibili_hk_mo_tw',
@@ -48,7 +48,9 @@ const siteList = [
   'prime',
 ];
 
-exports.add = async function add() {
+exports.add = async function add(onairSites) {
+  if (onairSites) siteList = Object.keys(onairSites);
+
   const defaultTime = dayjs().startOf('quarter').format('YYYYMMDDHHmmss');
   const getTime = (input = '', value = '') => {
     const start = `${input}`.slice(0, 14);

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -25,6 +25,7 @@ const invertedCycleList = Object.fromEntries(
 );
 
 const addedSitePref = '# ';
+const otherSitePref = ' '.repeat(addedSitePref.length);
 
 let baseSiteList = [
   'acfun',
@@ -59,7 +60,7 @@ let baseSiteList = [
 let addedSiteList = [];
 
 function addSitePref(site) {
-  return addedSiteList.has(site) ? addedSitePref + site : site;
+  return (addedSiteList.has(site) ? addedSitePref : otherSitePref) + site;
 }
 
 exports.add = async function add({ seqSites, onairSites, siteList }) {
@@ -100,7 +101,7 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
         }),
       },
     ]);
-    selectedSite = site.startsWith(addedSitePref) ? site.slice(addedSitePref.length) : site;
+    selectedSite = site.slice(addedSitePref.length);
   }
 
   if (siteList.length === 0) {

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -75,6 +75,22 @@ exports.init = function init(sites) {
   if (sites) baseSiteList = Object.keys(sites);
 }
 
+/** 判断待选放送站点列表中，是否包含已有的站点 */
+exports.includes = function includes(
+  seqSites,       // 已有的站点信息
+  siteList,       // 待选放送站点列表
+) {
+  getAddedSiteSet(seqSites);
+
+  if (siteList.length === 0)
+    return true;
+  const siteReg = new RegExp(`^(${siteList.join('|').replaceAll('*', '.*')})$`);
+  siteOptions = baseSiteList.filter((site) => siteReg.test(site));
+  return siteOptions.reduce(
+    (acc, site) => acc || addedSiteSet.has(site), false
+  );
+}
+
 exports.add = async function add({
   seqSites,       // 已有的站点信息
   siteList,       // 待选放送站点列表

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -119,10 +119,10 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
     }
   }
 
-  const preInfoIndex = seqSites.findIndex((site) => site.site === selectedSite);
-  const preInfo = seqSites[preInfoIndex];
-  if (preInfo?.begin) {
-    defaultTime = dayjs.utc(preInfo.begin).local().format('YYYYMMDDHHmmss');
+  const oldInfoIndex = seqSites.findIndex((site) => site.site === selectedSite);
+  const oldInfo = seqSites[oldInfoIndex];
+  if (oldInfo?.begin) {
+    defaultTime = dayjs.utc(oldInfo.begin).local().format('YYYYMMDDHHmmss');
   }
 
   const urlAnswers = await inquirer.prompt([
@@ -130,13 +130,13 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
       type: 'input',
       name: 'id',
       message: '站点 id',
-      default: preInfo?.id,
+      default: oldInfo?.id,
     },
     {
       type: 'input',
       name: 'url',
       message: '完整 url',
-      default: preInfo?.url,
+      default: oldInfo?.url,
       when: (a) => !a.id,
     },
   ]);
@@ -163,7 +163,7 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
       name: 'cycle',
       message: '周期',
       choices: Object.keys(cycleList),
-      default: invertedCycleList[preInfo?.broadcast.split('/').pop()] || '周播',
+      default: invertedCycleList[oldInfo?.broadcast.split('/').pop()] || '周播',
     },
     {
       type: 'input',
@@ -182,12 +182,12 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
       type: 'input',
       name: 'comment',
       message: '备注',
-      default: preInfo?.comment
+      default: oldInfo?.comment
     },
   ]);
 
   return {
-    preInfoIndex,
+    oldInfoIndex,
     info: {
       site: selectedSite,
       id: urlAnswers.id,

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -151,11 +151,14 @@ exports.add = async function add(seqSites, onairSites) {
   ]);
 
   return {
-    site: siteAnswers.site,
-    id: urlAnswers.id,
-    ...(urlAnswers.url ? { url: urlAnswers.url } : {}),
-    begin: dayjs(getTime(answers.begin).plainTime).toISOString(),
-    broadcast: `R/${dayjs(getTime(answers.broadcast, answers.begin).plainTime).toISOString()}/${cycleList[answers.cycle] || 'P7D'}`,
-    ...(answers.comment ? { comment: answers.comment } : {}),
+    preInfoIndex,
+    info: {
+      site: siteAnswers.site,
+      id: urlAnswers.id,
+      ...(urlAnswers.url ? { url: urlAnswers.url } : {}),
+      begin: dayjs(getTime(answers.begin).plainTime).toISOString(),
+      broadcast: `R/${dayjs(getTime(answers.broadcast, answers.begin).plainTime).toISOString()}/${cycleList[answers.cycle] || 'P7D'}`,
+      ...(answers.comment ? { comment: answers.comment } : {}),
+    }
   };
 };

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -27,6 +27,9 @@ const invertedCycleList = Object.fromEntries(
 const addedSitePref = '# ';
 const otherSitePref = ' '.repeat(addedSitePref.length);
 
+/** @type {Object<string, { urlTemplate: string }> | null} */
+let onairSites = null;
+
 let baseSiteList = [
   'acfun',
   'bilibili',
@@ -63,9 +66,13 @@ function addSitePref(site) {
   return (addedSiteSet.has(site) ? addedSitePref : otherSitePref) + site;
 }
 
+exports.init = function init(sites) {
+  onairSites = sites;
+  if (sites) baseSiteList = Object.keys(sites);
+}
+
 exports.add = async function add({
   seqSites,       // 已有的站点信息
-  onairSites,     // 所有放送站点列表
   siteList,       // 待选放送站点列表
   isFromValidate, // 由 validate 命令发起调用
 }) {

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -100,7 +100,7 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
   if (siteList.length === 0) {
     await selectSite(baseSiteList);
   } else {
-    const siteReg = new RegExp(`^(${siteList.join('|')})$`);
+    const siteReg = new RegExp(`^(${siteList.join('|').replaceAll('*', '.*')})$`);
     siteOptions = baseSiteList.filter((site) => siteReg.test(site));
     const length = siteOptions.length;
     if (length === 0) {
@@ -192,3 +192,4 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
     }
   };
 };
+    

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -86,6 +86,7 @@ exports.add = async function add({
   };
 
   let selectedSite = null;
+  const backOption = '↩ 返回其他番剧';
   const selectSite = async (options, again = false) => {
     if (again) {
       console.error('不支持所选站点', siteList, '请重新选择');
@@ -93,6 +94,7 @@ exports.add = async function add({
     options = options.map(
       (site) => addSitePref(site)
     );
+    options.push(backOption);
     const { site } = await inquirer.prompt([
       {
         type: 'autocomplete',
@@ -106,7 +108,11 @@ exports.add = async function add({
         }),
       },
     ]);
-    selectedSite = site.slice(addedSitePref.length);
+    if (site === backOption) {
+      selectedSite = undefined;
+    } else {
+      selectedSite = site.slice(addedSitePref.length);
+    }
   }
 
   if (siteList.length === 0) {
@@ -123,6 +129,9 @@ exports.add = async function add({
     } else {
       await selectSite(siteOptions);
     }
+  }
+  if (selectedSite === undefined) {
+    return undefined;
   }
 
   const oldInfoIndex = seqSites.findIndex((site) => site.site === selectedSite);

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -57,10 +57,10 @@ let baseSiteList = [
   'prime',
 ];
 
-let addedSiteList = [];
+let addedSiteSet = null;
 
 function addSitePref(site) {
-  return (addedSiteList.has(site) ? addedSitePref : otherSitePref) + site;
+  return (addedSiteSet.has(site) ? addedSitePref : otherSitePref) + site;
 }
 
 exports.add = async function add({
@@ -69,8 +69,7 @@ exports.add = async function add({
   siteList,       // 待选放送站点列表
   isFromValidate, // 由 validate 命令发起调用
 }) {
-  if (onairSites) baseSiteList = Object.keys(onairSites);
-  addedSiteList = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
+  addedSiteSet = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
 
   let defaultTime = dayjs().startOf('quarter').format('YYYYMMDDHHmmss');
   const getTime = (input = '', value = '') => {

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -63,7 +63,12 @@ function addSitePref(site) {
   return (addedSiteList.has(site) ? addedSitePref : otherSitePref) + site;
 }
 
-exports.add = async function add({ seqSites, onairSites, siteList }) {
+exports.add = async function add({
+  seqSites,       // 已有的站点信息
+  onairSites,     // 所有放送站点列表
+  siteList,       // 待选放送站点列表
+  isFromValidate, // 由 validate 命令发起调用
+}) {
   if (onairSites) baseSiteList = Object.keys(onairSites);
   addedSiteList = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
 
@@ -112,7 +117,7 @@ exports.add = async function add({ seqSites, onairSites, siteList }) {
     const length = siteOptions.length;
     if (length === 0) {
       await selectSite(baseSiteList, true);
-    } else if (length === 1) {
+    } else if (length === 1 && isFromValidate) {
       selectedSite = siteOptions[0];
       ora().succeed(`站点名称 ${chalk.cyan(addSitePref(selectedSite))}`);
     } else {

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -54,7 +54,7 @@ let siteList = [
   'prime',
 ];
 
-exports.add = async function add(seqSites, onairSites) {
+exports.add = async function add({ seqSites, onairSites, selectSite }) {
   if (onairSites) siteList = Object.keys(onairSites);
   const addedSites = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
   siteList = siteList.map((site) => addedSites.has(site) ? addedSitePref + site : site);
@@ -72,24 +72,27 @@ exports.add = async function add(seqSites, onairSites) {
     };
   };
 
-  const siteAnswers = await inquirer.prompt([
-    {
-      type: 'autocomplete',
-      name: 'site',
-      message: '站点名称',
-      source: (_, i = '') => new Promise((resolve) => {
-        const fuzzyResult = fuzzy.filter(i, siteList);
-        resolve(
-          fuzzyResult.map((el) => el.original),
-        );
-      }),
-    },
-  ]);
-  if (siteAnswers.site.startsWith(addedSitePref)) {
-    siteAnswers.site = siteAnswers.site.slice(addedSitePref.length);
+  if (!selectSite) {
+    const siteAnswers = await inquirer.prompt([
+      {
+        type: 'autocomplete',
+        name: 'site',
+        message: '站点名称',
+        source: (_, i = '') => new Promise((resolve) => {
+          const fuzzyResult = fuzzy.filter(i, siteList);
+          resolve(
+            fuzzyResult.map((el) => el.original),
+          );
+        }),
+      },
+    ]);
+    if (siteAnswers.site.startsWith(addedSitePref)) {
+      siteAnswers.site = siteAnswers.site.slice(addedSitePref.length);
+    }
+    selectSite = siteAnswers.site;
   }
 
-  const preInfoIndex = seqSites.findIndex((site) => site.site === siteAnswers.site);
+  const preInfoIndex = seqSites.findIndex((site) => site.site === selectSite);
   const preInfo = seqSites[preInfoIndex];
   if (preInfo?.begin) {
     defaultTime = dayjs.utc(preInfo.begin).local().format('YYYYMMDDHHmmss');
@@ -113,7 +116,7 @@ exports.add = async function add(seqSites, onairSites) {
 
   if (onairSites) {
     const url = urlAnswers.url
-      ?? onairSites[siteAnswers.site].urlTemplate.replace('{{id}}', urlAnswers.id);
+      ?? onairSites[selectSite].urlTemplate.replace('{{id}}', urlAnswers.id);
     console.log({ url });
   }
 
@@ -160,7 +163,7 @@ exports.add = async function add(seqSites, onairSites) {
   return {
     preInfoIndex,
     info: {
-      site: siteAnswers.site,
+      site: selectSite,
       id: urlAnswers.id,
       ...(urlAnswers.url ? { url: urlAnswers.url } : {}),
       begin: dayjs(getTime(answers.begin).plainTime).toISOString(),

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -4,6 +4,8 @@ const timezone = require('dayjs/plugin/timezone');
 const quarterOfYear = require('dayjs/plugin/quarterOfYear');
 const dayjs = require('dayjs');
 const fuzzy = require('fuzzy');
+const ora = require('ora');
+const chalk = require('chalk');
 
 inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
 
@@ -24,7 +26,7 @@ const invertedCycleList = Object.fromEntries(
 
 const addedSitePref = '# ';
 
-let siteList = [
+let baseSiteList = [
   'acfun',
   'bilibili',
   'bilibili_hk_mo_tw',
@@ -54,10 +56,9 @@ let siteList = [
   'prime',
 ];
 
-exports.add = async function add({ seqSites, onairSites, selectSite }) {
-  if (onairSites) siteList = Object.keys(onairSites);
+exports.add = async function add({ seqSites, onairSites, siteList }) {
+  if (onairSites) baseSiteList = Object.keys(onairSites);
   const addedSites = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
-  siteList = siteList.map((site) => addedSites.has(site) ? addedSitePref + site : site);
 
   let defaultTime = dayjs().startOf('quarter').format('YYYYMMDDHHmmss');
   const getTime = (input = '', value = '') => {
@@ -72,27 +73,47 @@ exports.add = async function add({ seqSites, onairSites, selectSite }) {
     };
   };
 
-  if (!selectSite) {
-    const siteAnswers = await inquirer.prompt([
+  let selectedSite = null;
+  const selectSite = async (options, again = false) => {
+    if (again) {
+      console.error('不支持所选站点', siteList, '请重新选择');
+    }
+    options = options.map(
+      (site) => addedSites.has(site) ? addedSitePref + site : site
+    );
+    const { site } = await inquirer.prompt([
       {
         type: 'autocomplete',
         name: 'site',
         message: '站点名称',
         source: (_, i = '') => new Promise((resolve) => {
-          const fuzzyResult = fuzzy.filter(i, siteList);
+          const fuzzyResult = fuzzy.filter(i, options);
           resolve(
             fuzzyResult.map((el) => el.original),
           );
         }),
       },
     ]);
-    if (siteAnswers.site.startsWith(addedSitePref)) {
-      siteAnswers.site = siteAnswers.site.slice(addedSitePref.length);
-    }
-    selectSite = siteAnswers.site;
+    selectedSite = site.startsWith(addedSitePref) ? site.slice(addedSitePref.length) : site;
   }
 
-  const preInfoIndex = seqSites.findIndex((site) => site.site === selectSite);
+  if (siteList.length === 0) {
+    await selectSite(baseSiteList);
+  } else {
+    const siteReg = new RegExp(`^(${siteList.join('|')})$`);
+    siteOptions = baseSiteList.filter((site) => siteReg.test(site));
+    const length = siteOptions.length;
+    if (length === 0) {
+      await selectSite(baseSiteList, true);
+    } else if (length === 1) {
+      selectedSite = siteOptions[0];
+      ora().succeed(`站点名称 ${chalk.cyan(selectedSite)}`);
+    } else {
+      await selectSite(siteOptions);
+    }
+  }
+
+  const preInfoIndex = seqSites.findIndex((site) => site.site === selectedSite);
   const preInfo = seqSites[preInfoIndex];
   if (preInfo?.begin) {
     defaultTime = dayjs.utc(preInfo.begin).local().format('YYYYMMDDHHmmss');
@@ -114,10 +135,9 @@ exports.add = async function add({ seqSites, onairSites, selectSite }) {
     },
   ]);
 
-  if (onairSites) {
-    const url = urlAnswers.url
-      ?? onairSites[selectSite].urlTemplate.replace('{{id}}', urlAnswers.id);
-    console.log({ url });
+  if (onairSites && !urlAnswers.url) {
+    const url = onairSites[selectedSite].urlTemplate.replace('{{id}}', urlAnswers.id);
+    ora().succeed(`完整 url ${chalk.cyan(url)}`);
   }
 
   const answers = await inquirer.prompt([
@@ -163,7 +183,7 @@ exports.add = async function add({ seqSites, onairSites, selectSite }) {
   return {
     preInfoIndex,
     info: {
-      site: selectSite,
+      site: selectedSite,
       id: urlAnswers.id,
       ...(urlAnswers.url ? { url: urlAnswers.url } : {}),
       begin: dayjs(getTime(answers.begin).plainTime).toISOString(),

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -66,6 +66,10 @@ function addSitePref(site) {
   return (addedSiteSet.has(site) ? addedSitePref : otherSitePref) + site;
 }
 
+function getAddedSiteSet(seqSites) {
+  addedSiteSet = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
+}
+
 exports.init = function init(sites) {
   onairSites = sites;
   if (sites) baseSiteList = Object.keys(sites);
@@ -76,7 +80,7 @@ exports.add = async function add({
   siteList,       // 待选放送站点列表
   isFromValidate, // 由 validate 命令发起调用
 }) {
-  addedSiteSet = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
+  getAddedSiteSet(seqSites);
 
   let defaultTime = dayjs().startOf('quarter').format('YYYYMMDDHHmmss');
   const getTime = (input = '', value = '') => {

--- a/lib/sites/onair.js
+++ b/lib/sites/onair.js
@@ -22,6 +22,8 @@ const invertedCycleList = Object.fromEntries(
   Object.entries(cycleList).map(([key, value]) => [value, key])
 );
 
+const addedSitePref = '# ';
+
 let siteList = [
   'acfun',
   'bilibili',
@@ -54,6 +56,8 @@ let siteList = [
 
 exports.add = async function add(seqSites, onairSites) {
   if (onairSites) siteList = Object.keys(onairSites);
+  const addedSites = seqSites.reduce((acc, site) => acc.add(site.site), new Set());
+  siteList = siteList.map((site) => addedSites.has(site) ? addedSitePref + site : site);
 
   let defaultTime = dayjs().startOf('quarter').format('YYYYMMDDHHmmss');
   const getTime = (input = '', value = '') => {
@@ -81,6 +85,9 @@ exports.add = async function add(seqSites, onairSites) {
       }),
     },
   ]);
+  if (siteAnswers.site.startsWith(addedSitePref)) {
+    siteAnswers.site = siteAnswers.site.slice(addedSitePref.length);
+  }
 
   const preInfoIndex = seqSites.findIndex((site) => site.site === siteAnswers.site);
   const preInfo = seqSites[preInfoIndex];

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -237,3 +237,27 @@ exports.matchBangumi = async function matchBangumi(input, options) {
   }
   return todo;
 }
+
+/** 修复 autocomplete prompt 初次渲染时默认项不可见的问题 */
+const AutocompletePrompt = require('inquirer-autocomplete-prompt');
+
+// 保存原始的 search 方法
+const originalSearch = AutocompletePrompt.prototype.search;
+
+// 重写 search 方法
+AutocompletePrompt.prototype.search = function (searchTerm) {
+  const searchPromise = originalSearch.call(this, searchTerm);
+
+  // 仅在首次渲染时进行额外处理
+  if (this.firstRender) {
+    searchPromise.then(() => {
+      this.firstRender = false;
+      const originalInfinite = this.paginator.isInfinite;
+      this.paginator.isInfinite = false; // 暂时使用有限分页，使默认项居中显示
+      this.render();
+      this.paginator.isInfinite = originalInfinite;
+    });
+  }
+  return searchPromise;
+};
+exports.AutocompletePrompt = AutocompletePrompt;


### PR DESCRIPTION
- `edit` 命令执行 `onair.add` 时，支持将可能存在的站点信息作为输入的默认值，选择站点时以 `#` 前缀标记已存在的站点
- `edit` 命令支持 `force` 参数，可以对站点信息进行强制覆写
- `edit` 与 `onair.add` 交互均支持循环操作

演示：
![2025-05-23-3892](https://github.com/user-attachments/assets/f09fbc96-70f0-419f-ab1c-7bca52cf6ffa)
