### PR TITLE
修复 bilibili 页面上开播时间的获取

### DIFF
--- a/lib/crawlers/bilibili.js
+++ b/lib/crawlers/bilibili.js
@@ -57,15 +57,29 @@ exports.getAll = async function getAll() {
   }));
 };
 
-async function getBegeinBeforeRelease(mediaId) {
+async function getBegeinFromWebsite(mediaId) {
   const url = `https://www.bilibili.com/bangumi/media/md${mediaId}/`;
   const html = await fetch(url).then((res) => res.text());
-  const [pubMatch, year] = html.match(/"pub_date":"(\d{4})-\d{1,2}-\d{1,2}"/) || [];
-  const [dateMatch, month, day, hour, minute] = html.match(/"release_date_show":"(\d{1,2})月(\d{1,2})日(\d{1,2}):(\d{1,2})开播"/) || [];
-  if (!pubMatch || !dateMatch) {
-    return null;
+  
+  // before release
+  let [pubMatch, year] = html.match(/"pub_date":"(\d{4})-\d{1,2}-\d{1,2}"/) || [];
+  let [dateMatch, month, day, hour, minute] = html.match(/"release_date_show":"(\d{1,2})月(\d{1,2})日(\d{1,2}):(\d{1,2})开播"/) || [];
+  if (pubMatch && dateMatch) {
+    return parseDate(year, month, day, hour, minute);
   }
+  // onair eg:
+  // <div class="media-info-time"><span>2025年4月1日开播</span> <span>连载中, 每周二 22:30更新</span></div>
+  let timeMatch;
+  [dateMatch, year, month, day] = html.match(/"media-info-time".+?(\d{4})年(\d{1,2})月(\d{1,2})日开播/) || [];
+  [timeMatch, hour, minute] = html.match(/"media-info-time".+?(\d{1,2}):(\d{1,2})更新/) || [, 8, 0];
+  if (dateMatch) {
+    // 已完结的与部分港台番剧将缺失 hour, minute 将自动填充为 T00:00Z
+    return parseDate(year, month, day, hour, minute);
+  }
+  return null;
+}
 
+function parseDate(year, month, day, hour, minute) {
   try {
     const date = new Date(`${year}-${month}-${day} ${hour}:${minute}:00 +08:00`);
     return date;
@@ -77,20 +91,20 @@ async function getBegeinBeforeRelease(mediaId) {
 
 exports.getBegin = async function getBegin(mediaId, site) {
   const api = `https://bangumi.bilibili.com/view/web_api/media?media_id=${mediaId}`;
-  const { result } = await fetch(api).then((res) => res.json());
-  if (site && site === 'bilibili' && result.episodes[0].mid === 11783021) {
+  const { result } = await fetch(api).then((res) => res.json()).catch(() => ({}));
+  if (site && site === 'bilibili' && result?.episodes[0].mid === 11783021) {
     ora().fail(`uploader is 哔哩哔哩番剧出差 (mediaId: ${mediaId})`);
-  } else if(site && site !== 'bilibili' && result.episodes[0].mid !== 11783021){
+  } else if(site && site !== 'bilibili' && result?.episodes[0].mid !== 11783021){
     ora().fail(`uploader is not 哔哩哔哩番剧出差 (mediaId: ${mediaId})`);
   }
-  let time = result.episodes
+  let time = result?.episodes
     .filter((ep) => !Number.isNaN(Number(ep.index)))
     .map((ep) => new Date(`${ep.pub_real_time}+08:00`))
     .sort((a, b) => a - b)
     .shift();
 
   if (!time) {
-    time = await getBegeinBeforeRelease(mediaId);
+    time = await getBegeinFromWebsite(mediaId);
   }
 
   return time ? time.toISOString() : '';


### PR DESCRIPTION
 - 原 `https://bangumi.bilibili.com/view/web_api/media?media_id=${media_id}` API似乎已经废止，据 [[bilibili-API-collect]](https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/bangumi/info.md) 内的说明，目前无法直接通过 `mediaId` 在公开API内获取相关番剧信息，而是需求与 `media_id` 对应的 `season_id`
 - 捕获并截断了原API错误信息的传递
 - 采用了新的方法获取页面上开播时间，目前开播时间的年月日可以从网页中准确获取，但开播的时分似乎只有大陆的在放送的番剧才具备该信息